### PR TITLE
Fix crash

### DIFF
--- a/scenes/strategic-point.gd
+++ b/scenes/strategic-point.gd
@@ -39,6 +39,7 @@ func hide_strategic_point_menu():
 	if tower and tower.state == tower.TOWER_STATES.PREVIEW:
 		Utils.delete_children_from_node(tower_container)
 		sprite.show()
+	last_slot_pressed = null
 
 
 func _on_slot_pressed(slot: Slot):


### PR DESCRIPTION
The game crashed when a user made the buttons disappear by clicking elsewhere, and then reopening the menu and selecting the same tower

- [x] I did read the [project licensing](https://github.com/crystal-bit/hacktoberfest-2020#license) and I agree with the content of this Pull Request being licensed under the same conditions.
