### PR TITLE
Implement tower and missile rotation

### DIFF
--- a/scenes/credits.gd
+++ b/scenes/credits.gd
@@ -16,6 +16,7 @@ var contributors = [
 	"m0rp30",
 	"Iranon",
 	"masmart",
+	"gVirtu",
 ]
 
 onready var labels_container = $LabelsContainer

--- a/scenes/tower/tower.gd
+++ b/scenes/tower/tower.gd
@@ -3,6 +3,8 @@ class_name Tower
 
 export(Resource) var tower_resource
 
+const TOWER_ROTATION_OFFSET = PI / 2
+
 onready var attack_range_area: Area2D = $AttackRange/AttackRange
 onready var rally_point = $RallyPoint
 onready var sprite = $Sprite
@@ -32,7 +34,12 @@ func initialise(_resource: Resource):
 func _ready() -> void:
 	attack_range_area.monitoring = false
 	load_resource_data(tower_resource)
-
+	
+func _process(delta):
+	if target is Enemy:
+		var to_target = (target.global_position - global_position).normalized()
+		var rotation_to_target = to_target.angle() + TOWER_ROTATION_OFFSET
+		sprite.rotation = lerp_angle(sprite.rotation, rotation_to_target, 0.25)
 
 func _draw() -> void:
 	var blue_color: Color = Color.blue
@@ -101,7 +108,8 @@ func load_resource_data(tower_resource : Tower_Resource):
 
 func fire(_target: Enemy):
 	var ammo = missile_scene.instance()
-	ammo.shot_direction = (_target.global_position - global_position).normalized()
+	var to_target = (_target.global_position - global_position).normalized()
+	ammo.shot_direction = to_target
 	ammo.set_position(position)
-	ammo.set_rotation(rotation) #tower should rotate
+	ammo.set_rotation(to_target.angle() + TOWER_ROTATION_OFFSET)
 	add_child(ammo)


### PR DESCRIPTION
This PR closes issue #88 .

Turret rotation was applied only to the sprite, if applied to the whole `Tower` resource it would cause all of the missiles to "orbit" around it, since they are added as children. `lerp_angle` was used to make it look nicer. :)

Missile rotation is no longer based on `Tower` rotation for the same reason above. Instead, we reuse the direction to target Vector that was already being passed to `shot_direction`. 

![turret](https://user-images.githubusercontent.com/15658199/97090962-9fb93380-160e-11eb-9c0f-a757aba0af58.gif)

--------------------------------------------

Before submitting a Pull Request please read and tick this checkbox:

- [x] I did read the [project licensing](https://github.com/crystal-bit/hacktoberfest-2020#license) and I agree with the content of this Pull Request being licensed under the same conditions.
