### PR TITLE
Fix Issue #100 (Towers don't fire sometimes)

### DIFF
--- a/scenes/tower/tower.tscn
+++ b/scenes/tower/tower.tscn
@@ -8,6 +8,7 @@
 extents = Vector2( 24.8515, 28.2729 )
 
 [sub_resource type="CircleShape2D" id=2]
+resource_local_to_scene = true
 radius = 16.0
 
 [node name="Tower" type="Node2D"]


### PR DESCRIPTION
Before submitting a Pull Request please read and tick this checkbox:

- [X] I did read the [project licensing](https://github.com/crystal-bit/hacktoberfest-2020#license) and I agree with the content of this Pull Request being licensed under the same conditions.

Bug:
All the towers in the level get the attack_range's radius from the last tower buyed.

Reproduce:
- Buy first a Sniper tower and then a Missile tower: the Sniper tower don't fire though enemies enter in his range (see blue circle).
- Buy first a Missile tower and then a Sniper tower: the Missile tower fire though enemies are out of the range (see blue circle).

Reason:
The sub resource AttackRange/CollisionShape2D/CircleShape2D of tower.tscn is shared between all towers in the level.

Fix:
Set resource_local_to_scene property of CircleShape2D to true

Sorry for the verbose comment 🙃 